### PR TITLE
Change color in "Markdown Result" section

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -106,7 +106,7 @@ h4 {
 
 p {
   margin-bottom: 1.25rem;
-  color: var(--clr-grey-9);
+  color: var(--clr-grey-1);
 }
 
 /*use media query for making responsive ui*/

--- a/src/index.css
+++ b/src/index.css
@@ -106,7 +106,7 @@ h4 {
 
 p {
   margin-bottom: 1.25rem;
-  color: var(--clr-grey-1);
+  color: var(--clr-primary-3);
 }
 
 /*use media query for making responsive ui*/


### PR DESCRIPTION
Text wasn't visible in light theme and dark theme together. This color will comfortablly allow to see in both theme together. Screenshots are attached.<br>
<b>Updated preview</b>
<img width="938" alt="2" src="https://user-images.githubusercontent.com/84512702/139042026-9781f7c5-e79b-4a2e-ae78-9d75dc7552da.png">
<img width="939" alt="1" src="https://user-images.githubusercontent.com/84512702/139042020-968eca79-464f-4a88-a1bf-dc2a8c777c18.png">
<br>
<hr>
<br>
<b>Your preview</b>
<img width="935" alt="3" src="https://user-images.githubusercontent.com/84512702/139042027-4e69b73f-c1b0-48b3-8ba6-8838f241bad2.png">
<img width="938" alt="4" src="https://user-images.githubusercontent.com/84512702/139042028-eca9540d-1585-440a-8d34-f755cda41631.png">
